### PR TITLE
Add accessible profile builder page with resume export

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -9,12 +9,13 @@ import { ApplicationPage } from './pages/ApplicationPage';
 import { EmployerDashboard } from './pages/EmployerDashboard';
 import { AdminDashboard } from './pages/AdminDashboard';
 import { ProfilePage } from './pages/ProfilePage';
+import { ProfileBuilder } from './pages/ProfileBuilder';
 
 const AppLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
-    <div className="min-vh-100 d-flex flex-column">
+    <div className='min-vh-100 d-flex flex-column'>
       <Navigation />
-      <main className="flex-grow-1" id="main-content">
+      <main className='flex-grow-1' id='main-content'>
         {children}
       </main>
     </div>
@@ -24,15 +25,79 @@ const AppLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 export const AppRouter: React.FC = () => {
   return (
     <Routes>
-      <Route path="/login" element={<LoginPage />} />
-      <Route path="/" element={<AppLayout><Navigate to="/jobs" replace /></AppLayout>} />
-      <Route path="/dashboard" element={<AppLayout><CandidateDashboard /></AppLayout>} />
-      <Route path="/jobs" element={<AppLayout><JobSearchPage /></AppLayout>} />
-      <Route path="/job/:id" element={<AppLayout><JobDetailPage /></AppLayout>} />
-      <Route path="/apply/:id" element={<AppLayout><ApplicationPage /></AppLayout>} />
-      <Route path="/employer" element={<AppLayout><EmployerDashboard /></AppLayout>} />
-      <Route path="/admin" element={<AppLayout><AdminDashboard /></AppLayout>} />
-      <Route path="/profile" element={<AppLayout><ProfilePage /></AppLayout>} />
+      <Route path='/login' element={<LoginPage />} />
+      <Route
+        path='/'
+        element={
+          <AppLayout>
+            <Navigate to='/jobs' replace />
+          </AppLayout>
+        }
+      />
+      <Route
+        path='/dashboard'
+        element={
+          <AppLayout>
+            <CandidateDashboard />
+          </AppLayout>
+        }
+      />
+      <Route
+        path='/jobs'
+        element={
+          <AppLayout>
+            <JobSearchPage />
+          </AppLayout>
+        }
+      />
+      <Route
+        path='/job/:id'
+        element={
+          <AppLayout>
+            <JobDetailPage />
+          </AppLayout>
+        }
+      />
+      <Route
+        path='/apply/:id'
+        element={
+          <AppLayout>
+            <ApplicationPage />
+          </AppLayout>
+        }
+      />
+      <Route
+        path='/employer'
+        element={
+          <AppLayout>
+            <EmployerDashboard />
+          </AppLayout>
+        }
+      />
+      <Route
+        path='/admin'
+        element={
+          <AppLayout>
+            <AdminDashboard />
+          </AppLayout>
+        }
+      />
+      <Route
+        path='/profile'
+        element={
+          <AppLayout>
+            <ProfilePage />
+          </AppLayout>
+        }
+      />
+      <Route
+        path='/profile-builder'
+        element={
+          <AppLayout>
+            <ProfileBuilder />
+          </AppLayout>
+        }
+      />
     </Routes>
   );
-}; 
+};

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -10,35 +10,46 @@ export const Navigation: React.FC = () => {
     { path: '/dashboard', label: 'Dashboard', icon: '📊' },
     { path: '/employer', label: 'Empleador', icon: '🏢' },
     { path: '/admin', label: 'Admin', icon: '⚙️' },
+    { path: '/profile-builder', label: 'Crear Perfil', icon: '📝' },
     { path: '/profile', label: 'Perfil', icon: '👤' },
   ];
 
   return (
-    <nav className="navbar navbar-expand-lg navbar-light bg-white shadow-sm sticky-top">
-      <div className="container">
+    <nav className='navbar navbar-expand-lg navbar-light bg-white shadow-sm sticky-top'>
+      <div className='container'>
         {/* Enhanced Logo */}
-        <Link to="/jobs" className="navbar-brand d-flex align-items-center text-decoration-none">
-          <div className="bg-gradient-primary rounded-circle d-flex align-items-center justify-content-center shadow-custom me-3" style={{ width: '40px', height: '40px' }}>
-            <span className="text-white fw-bold">E+</span>
+        <Link
+          to='/jobs'
+          className='navbar-brand d-flex align-items-center text-decoration-none'
+        >
+          <div
+            className='bg-gradient-primary rounded-circle d-flex align-items-center justify-content-center shadow-custom me-3'
+            style={{ width: '40px', height: '40px' }}
+          >
+            <span className='text-white fw-bold'>E+</span>
           </div>
-          <span className="text-gradient fw-bold fs-4">Emplea+</span>
+          <span className='text-gradient fw-bold fs-4'>Emplea+</span>
         </Link>
 
         {/* Mobile menu button */}
         <button
-          className="navbar-toggler border-0"
-          type="button"
+          className='navbar-toggler border-0'
+          type='button'
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-          aria-label="Toggle navigation"
+          aria-label='Toggle navigation'
         >
-          <span className="navbar-toggler-icon"></span>
+          <span className='navbar-toggler-icon'></span>
         </button>
 
         {/* Navigation Links */}
-        <div className={`collapse navbar-collapse ${isMobileMenuOpen ? 'show' : ''}`}>
-          <ul className="navbar-nav ms-auto mb-2 mb-lg-0">
-            {navItems.map((item) => (
-              <li className="nav-item" key={item.path}>
+        <div
+          className={`collapse navbar-collapse ${
+            isMobileMenuOpen ? 'show' : ''
+          }`}
+        >
+          <ul className='navbar-nav ms-auto mb-2 mb-lg-0'>
+            {navItems.map(item => (
+              <li className='nav-item' key={item.path}>
                 <Link
                   to={item.path}
                   onClick={() => setIsMobileMenuOpen(false)}
@@ -48,7 +59,7 @@ export const Navigation: React.FC = () => {
                       : 'text-muted hover:text-primary'
                   }`}
                 >
-                  <span className="me-2 fs-5">{item.icon}</span>
+                  <span className='me-2 fs-5'>{item.icon}</span>
                   <span>{item.label}</span>
                 </Link>
               </li>
@@ -58,4 +69,4 @@ export const Navigation: React.FC = () => {
       </div>
     </nav>
   );
-}; 
+};

--- a/src/pages/ProfileBuilder.tsx
+++ b/src/pages/ProfileBuilder.tsx
@@ -1,0 +1,259 @@
+import React, { useState } from 'react';
+import { useAccessibility } from '../context/AccessibilityContext';
+
+interface ResumeData {
+  personal: {
+    name: string;
+    email: string;
+    phone: string;
+  };
+  skills: string;
+  accommodations: string;
+  experience: string;
+}
+
+export const ProfileBuilder: React.FC = () => {
+  const { highContrast, easyReading, fontSize, colorScheme } =
+    useAccessibility();
+  const [step, setStep] = useState(1);
+  const totalSteps = 4;
+  const [resume, setResume] = useState<ResumeData>({
+    personal: { name: '', email: '', phone: '' },
+    skills: '',
+    accommodations: '',
+    experience: '',
+  });
+  const [announcement, setAnnouncement] = useState(
+    `Paso 1 de ${totalSteps}: Datos personales`
+  );
+
+  const accessibilityClasses = [
+    highContrast ? 'high-contrast' : '',
+    easyReading ? 'easy-reading' : '',
+    `font-size-${fontSize}`,
+    colorScheme !== 'default'
+      ? colorScheme === 'high-contrast'
+        ? 'high-contrast'
+        : colorScheme === 'colorblind'
+        ? 'colorblind'
+        : 'dark-mode'
+      : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const stepNames = [
+    'Datos personales',
+    'Habilidades',
+    'Acomodaciones',
+    'Experiencia',
+  ];
+
+  const updateAnnouncement = (newStep: number) => {
+    setAnnouncement(
+      `Paso ${newStep} de ${totalSteps}: ${stepNames[newStep - 1]}`
+    );
+  };
+
+  const next = () => {
+    const newStep = Math.min(step + 1, totalSteps);
+    setStep(newStep);
+    updateAnnouncement(newStep);
+  };
+
+  const prev = () => {
+    const newStep = Math.max(step - 1, 1);
+    setStep(newStep);
+    updateAnnouncement(newStep);
+  };
+
+  const handlePersonalChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setResume(prev => ({
+      ...prev,
+      personal: {
+        ...prev.personal,
+        [name]: value,
+      },
+    }));
+  };
+
+  const handleFieldChange = (
+    field: 'skills' | 'accommodations' | 'experience',
+    value: string
+  ) => {
+    setResume(prev => ({ ...prev, [field]: value }));
+  };
+
+  const saveResume = () => {
+    localStorage.setItem('resumeData', JSON.stringify(resume));
+    setAnnouncement('Currículum guardado');
+  };
+
+  const generateHTML = () => {
+    return `
+      <h1>${resume.personal.name}</h1>
+      <p>Email: ${resume.personal.email}</p>
+      <p>Teléfono: ${resume.personal.phone}</p>
+      <h2>Habilidades</h2>
+      <p>${resume.skills}</p>
+      <h2>Acomodaciones</h2>
+      <p>${resume.accommodations}</p>
+      <h2>Experiencia</h2>
+      <p>${resume.experience}</p>
+    `;
+  };
+
+  const exportPDF = () => {
+    window.print();
+  };
+
+  const exportHTML = () => {
+    const html = `<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Currículum</title></head><body>${generateHTML()}</body></html>`;
+    const blob = new Blob([html], { type: 'text/html' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'resume.html';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className={`container my-4 ${accessibilityClasses}`}>
+      <div className='progress mb-4' aria-label='Progreso del formulario'>
+        <div
+          className='progress-bar'
+          role='progressbar'
+          style={{ width: `${(step / totalSteps) * 100}%` }}
+          aria-valuenow={(step / totalSteps) * 100}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          {`Paso ${step} de ${totalSteps}`}
+        </div>
+      </div>
+      <div aria-live='polite' className='sr-only'>
+        {announcement}
+      </div>
+
+      {step === 1 && (
+        <div>
+          <div className='mb-3'>
+            <label htmlFor='name' className='form-label'>
+              Nombre
+            </label>
+            <input
+              id='name'
+              name='name'
+              type='text'
+              className='form-control'
+              value={resume.personal.name}
+              onChange={handlePersonalChange}
+            />
+          </div>
+          <div className='mb-3'>
+            <label htmlFor='email' className='form-label'>
+              Email
+            </label>
+            <input
+              id='email'
+              name='email'
+              type='email'
+              className='form-control'
+              value={resume.personal.email}
+              onChange={handlePersonalChange}
+            />
+          </div>
+          <div className='mb-3'>
+            <label htmlFor='phone' className='form-label'>
+              Teléfono
+            </label>
+            <input
+              id='phone'
+              name='phone'
+              type='tel'
+              className='form-control'
+              value={resume.personal.phone}
+              onChange={handlePersonalChange}
+            />
+          </div>
+        </div>
+      )}
+
+      {step === 2 && (
+        <div className='mb-3'>
+          <label htmlFor='skills' className='form-label'>
+            Habilidades
+          </label>
+          <textarea
+            id='skills'
+            className='form-control'
+            value={resume.skills}
+            onChange={e => handleFieldChange('skills', e.target.value)}
+          />
+        </div>
+      )}
+
+      {step === 3 && (
+        <div className='mb-3'>
+          <label htmlFor='accommodations' className='form-label'>
+            Acomodaciones
+          </label>
+          <textarea
+            id='accommodations'
+            className='form-control'
+            value={resume.accommodations}
+            onChange={e => handleFieldChange('accommodations', e.target.value)}
+          />
+        </div>
+      )}
+
+      {step === 4 && (
+        <div>
+          <div className='mb-3'>
+            <label htmlFor='experience' className='form-label'>
+              Experiencia
+            </label>
+            <textarea
+              id='experience'
+              className='form-control'
+              value={resume.experience}
+              onChange={e => handleFieldChange('experience', e.target.value)}
+            />
+          </div>
+          <button className='btn btn-success me-2' onClick={saveResume}>
+            Guardar
+          </button>
+          <button className='btn btn-primary me-2' onClick={exportPDF}>
+            Exportar PDF
+          </button>
+          <button className='btn btn-secondary' onClick={exportHTML}>
+            Exportar HTML
+          </button>
+          <div className='mt-4'>
+            <h3>Vista previa</h3>
+            <div dangerouslySetInnerHTML={{ __html: generateHTML() }} />
+          </div>
+        </div>
+      )}
+
+      <div className='d-flex justify-content-between mt-4'>
+        {step > 1 && (
+          <button className='btn btn-outline-secondary' onClick={prev}>
+            Atrás
+          </button>
+        )}
+        {step < totalSteps && (
+          <button className='btn btn-primary ms-auto' onClick={next}>
+            Siguiente
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ProfileBuilder;


### PR DESCRIPTION
## Summary
- add ProfileBuilder page with multi-step resume form
- persist resume data and allow PDF or HTML export
- register ProfileBuilder route and navigation link

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689a21c74f0883268c5711a99287de6d